### PR TITLE
Update for Django 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: python
 python:
-    - "2.7"
-    - "3.4"
     - "3.5"
     - "3.6"
-    - "pypy"
 
 install:
     - pip install --upgrade -r requirements.txt

--- a/Artifactorial/models.py
+++ b/Artifactorial/models.py
@@ -23,6 +23,7 @@ from django.contrib.auth.models import User, Group
 from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
 from django.db import models
+from django.urls import reverse
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.timezone import datetime, utc
 
@@ -38,7 +39,7 @@ def random_hash():
 
 @python_2_unicode_compatible
 class AuthToken(models.Model):
-    user = models.ForeignKey(User, blank=False)
+    user = models.ForeignKey(User, blank=False, on_delete=models.CASCADE)
     secret = models.TextField(max_length=32, unique=True, default=random_hash)
     description = models.TextField(null=False, blank=True)
 
@@ -53,8 +54,8 @@ class AuthToken(models.Model):
 class Directory(models.Model):
     path = models.CharField(max_length=300, unique=True,
                             null=False, blank=False)
-    user = models.ForeignKey(User, null=True, blank=True)
-    group = models.ForeignKey(Group, null=True, blank=True)
+    user = models.ForeignKey(User, null=True, blank=True, on_delete=models.SET_NULL)
+    group = models.ForeignKey(Group, null=True, blank=True, on_delete=models.SET_NULL)
     is_public = models.BooleanField(default=False)
     ttl = models.IntegerField(blank=False, default=90,
                               help_text="Files TTL in days")
@@ -85,9 +86,8 @@ class Directory(models.Model):
         else:
             return "%s (anonymous)" % (self.path)
 
-    @models.permalink
     def get_absolute_url(self):
-        return ("artifacts", [self.path[1:] + '/'])
+        return reverse("artifacts", args=[self.path[1:] + '/'])
 
     def is_visible_to(self, user):
         """
@@ -164,16 +164,15 @@ def get_path_name(instance, filename):
 @python_2_unicode_compatible
 class Artifact(models.Model):
     path = models.FileField(upload_to=get_path_name)
-    directory = models.ForeignKey(Directory, blank=False)
+    directory = models.ForeignKey(Directory, blank=False, on_delete=models.CASCADE)
     is_permanent = models.BooleanField(default=False)
     created_at = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):
         return self.path.name
 
-    @models.permalink
     def get_absolute_url(self):
-        return ("artifacts", [self.path.name])
+        return reverse("artifacts", [self.path.name])
 
     def is_visible_to(self, user):
         return self.directory.is_visible_to(user)
@@ -185,12 +184,11 @@ class Artifact(models.Model):
 @python_2_unicode_compatible
 class Share(models.Model):
     token = models.TextField(max_length=32, unique=True, default=random_hash)
-    artifact = models.ForeignKey(Artifact, blank=False)
-    user = models.ForeignKey(User, blank=False)
+    artifact = models.ForeignKey(Artifact, blank=False, on_delete=models.CASCADE)
+    user = models.ForeignKey(User, blank=False, on_delete=models.CASCADE)
 
     def __str__(self):
         return "%s -> %s" % (self.token, self.artifact)
 
-    @models.permalink
     def get_absolute_url(self):
-        return ("shares", [self.token])
+        return reverse("shares", [self.token])

--- a/Artifactorial/tests/test_http.py
+++ b/Artifactorial/tests/test_http.py
@@ -21,7 +21,7 @@ from __future__ import unicode_literals
 
 from django.contrib.auth.models import AnonymousUser, Group, User
 from django.core.management import call_command
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from Artifactorial.models import Artifact, AuthToken, Directory, Share
 

--- a/Artifactorial/urls.py
+++ b/Artifactorial/urls.py
@@ -21,7 +21,7 @@ from __future__ import unicode_literals
 
 from django.contrib.auth import views as v_auth
 from django.conf.urls import url
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 
 import Artifactorial.views as a_views
 
@@ -30,9 +30,9 @@ urlpatterns = [
     url(r'^$', a_views.home, name='home'),
 
     # Authentication
-    url(r'^accounts/login/$', v_auth.login, {'template_name': 'Artifactorial/accounts/login.html'}, name='accounts.login'),
-    url(r'^accounts/logout/$', v_auth.logout, {'template_name': 'Artifactorial/accounts/logged_out.html'}, name='accounts.logout'),
-    url(r'^accounts/password/change/$', v_auth.password_change, {'post_change_redirect': reverse_lazy('accounts.profile')}, name='accounts.password_change'),
+    url(r'^accounts/login/$', v_auth.LoginView.as_view(template_name='Artifactorial/accounts/login.html'), name='accounts.login'),
+    url(r'^accounts/logout/$', v_auth.LogoutView.as_view(template_name='Artifactorial/accounts/logged_out.html'), name='accounts.logout'),
+    url(r'^accounts/password/change/$', v_auth.PasswordChangeView.as_view(success_url=reverse_lazy('accounts.profile')), name='accounts.password_change'),
     url(r'^accounts/profile/$', a_views.profile, name='accounts.profile'),
 
     # Artifacts interactions

--- a/Artifactorial/views.py
+++ b/Artifactorial/views.py
@@ -19,7 +19,7 @@
 
 from __future__ import unicode_literals
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.contrib.auth.decorators import login_required
 from django.db.models import Q
 from django.forms import ModelForm
@@ -281,7 +281,7 @@ def shares_root(request):
                                 put.get('token', ''))
 
         # Anonymous users are not allowed to create shares
-        if user.is_anonymous():
+        if user.is_anonymous:
             return HttpResponseForbidden()
 
         # The user should have the right to read the artifact
@@ -315,7 +315,7 @@ def shares(request, token):
         # Get the current user
         user = get_current_user(request,
                                 request.GET.get('token', ''))
-        if user.is_anonymous():
+        if user.is_anonymous:
             return HttpResponseForbidden()
 
         share = get_object_or_404(Share, token=token)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-django
+Django==2.1

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -52,13 +52,12 @@ INSTALLED_APPS = [
     'Artifactorial',
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]


### PR DESCRIPTION
Add on_delete paramater to all foreign keys in models because Django 2.1
requires all foreign keys to include the on_delete paramater.

Use reverse instead of permalink because the permalink decorator has been
deprecated.

Replace django.core.urlresolvers with django.urls

Update the contrib.auth login, lougout, and password_change functions to
the new class-based views.